### PR TITLE
Removed unnecessary .close statements + Safer approach to changing a file name extension

### DIFF
--- a/src/glbin.py
+++ b/src/glbin.py
@@ -351,7 +351,6 @@ def texRead(file):
                 infile.seek(0)
                 data=infile.read()
 
-        infile.close()
         print(f"   > Success: {file.name} is valid")
         return io.BytesIO(data)
     except:

--- a/src/gltex.py
+++ b/src/gltex.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 from dataclasses import fields
 from gldc import pbox
@@ -14,7 +15,7 @@ def readMagic(file):
 
 def tex2png(file):
     filename=file.name
-    outfile=filename.replace(".tex", ".png")
+    outfile=os.path.splitext(filename)[0]+".png"
     print(f"-- Converting {filename}...")
 
     try:
@@ -38,7 +39,7 @@ def tex2png(file):
 
 def plax2png(file):
     filename=file.name
-    outfile=filename.replace(".tex", ".png")
+    outfile=os.path.splitext(filename)[0]+".png"
     print(f"-- Converting {filename}...")
 
     try:
@@ -52,7 +53,7 @@ def plax2png(file):
 
         root_split=root.split("/")
         root_name_tex=root_split[len(root_split)-1]
-        root_name=root_name_tex.replace(".tex", ".png")
+        root_name=os.path.splitext(root_name_tex)[0]+".png"
         path_root=file.parent/root_name
         path_root_tex=file.parent/root_name_tex
 

--- a/src/gltex.py
+++ b/src/gltex.py
@@ -9,7 +9,6 @@ from PIL import Image
 def readMagic(file):
     with open(file, "rb") as infile:
         magic=infile.read(4)
-        infile.close()
         
     return magic
 
@@ -29,7 +28,6 @@ def tex2png(file):
                 infile.seek(0)
                 data=infile.read()
 
-        infile.close()
         image=Image.open(io.BytesIO(data))
         w, h=image.size
         image.save(file.parent/outfile, "PNG")


### PR DESCRIPTION
# Removed unnecessary file close statements

You don't need to close files manually if you used the `with...as` block to open them.

https://stackoverflow.com/questions/21275836/if-youre-opening-a-file-using-the-with-statement-do-you-still-need-to-close

# Safe path extensions handling

By using `os.path.splitext()` instead of plain string replace we can avoid situations where a file has `.tex` in the name before the actual extension resulting in a path named `file.tex.tex` being changed to `file.png.png` instead of `file.tex.png`.

Although this is very rare to occur it's best to handle paths carefully.

More info in the links below:

https://stackoverflow.com/questions/3548673/how-can-i-replace-or-strip-an-extension-from-a-filename-in-python

https://www.geeksforgeeks.org/python-os-path-splitext-method/